### PR TITLE
feat: upgrade to 2.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kubectl create secret -n formbricks generic formbricks-secrets \
 ### Install Chart
 
 ```
-helm upgrade --install -n formbricks formbricks oci://ghcr.io/nmcclain/formbricks/formbricks --version 2.4.3
+helm upgrade --install -n formbricks formbricks oci://ghcr.io/nmcclain/formbricks/formbricks --version 2.5.1
 ```
 
 ## Releasing this Chart

--- a/formbricks/Chart.yaml
+++ b/formbricks/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.3
+version: 2.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.4.3"
+appVersion: "2.5.1"

--- a/formbricks/templates/job-upgrade-v2.5.yaml
+++ b/formbricks/templates/job-upgrade-v2.5.yaml
@@ -1,0 +1,25 @@
+{{- if semverCompare "~2.5.x" .Chart.AppVersion }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: formbricks-data-migrations-v2-5
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: formbricks-data-migrations-v2-5
+        image: ghcr.io/formbricks/data-migrations:v2.5.0
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.formbricks.databaseUrl.existingSecret.name }}
+              key: {{ .Values.formbricks.databaseUrl.existingSecret.key }}
+        - name: UPGRADE_TO_VERSION
+          value: "v2.5"
+      restartPolicy: Never
+  backoffLimit: 2
+{{- end }}


### PR DESCRIPTION
Upgrade current helm chart to 2.5.1.

Added the migration and 
changed "eq" test to "semverCompare" as the current last version is 2.5.1 but the migration was introduced with 2.5.0